### PR TITLE
[REVIEW] Memory Manager

### DIFF
--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -232,13 +232,21 @@ def apply_join(col_lhs, col_rhs, how, method='hash'):
 
     # yield ((ary[0], ary[1]) if datasize > 0 else (ary, ary))
 
-    left = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-                                                   col_result_l.data)),
-                              nelem=col_result_l.size, dtype=np.int32)
+    # left = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
+    #                                                col_result_l.data)),
+    #                           nelem=col_result_l.size, dtype=np.int32)
 
-    right = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-                                                    col_result_r.data)),
-                               nelem=col_result_r.size, dtype=np.int32)
+    # right = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
+    #                                                 col_result_r.data)),
+    #                            nelem=col_result_r.size, dtype=np.int32)
+
+    left = rmm.device_array_from_ptr(ptr = col_result_l.data,
+                                     nelem=col_result_l.size, 
+                                     dtype=np.int32)
+
+    right = rmm.device_array_from_ptr(ptr = col_result_r.data,
+                                      nelem=col_result_r.size, 
+                                      dtype=np.int32)
 
     yield(left, right)
 

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -553,8 +553,8 @@ def nvtx_range_pop():
     libgdf.gdf_nvtx_range_pop()
 
 
-def rmm_initialize(use_pool_allocator=False):
-    rmm.initialize(use_pool_allocator)
+def rmm_initialize(use_pool_allocator=False, enable_logging=False):
+    rmm.initialize(use_pool_allocator, enable_logging)
     return True
 
 

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -553,8 +553,8 @@ def nvtx_range_pop():
     libgdf.gdf_nvtx_range_pop()
 
 
-def rmm_initialize(use_cuda_malloc=False):
-    rmm.initialize(use_cuda_malloc)
+def rmm_initialize(use_pool_allocator=False):
+    rmm.initialize(use_pool_allocator)
     return True
 
 

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -551,3 +551,11 @@ def nvtx_range_pop():
     """ Demarcate the end of the inner-most range.
     """
     libgdf.gdf_nvtx_range_pop()
+
+def rmm_initialize(use_cuda_malloc = False):
+    rmm.initialize(use_cuda_malloc)
+    return True
+
+def rmm_finalize():
+    rmm.finalize()
+    return True

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -211,58 +211,20 @@ _join_method_api = {
 }
 
 
-def _make_mem_finalizer(dtor, bytesize):
-    """Make memory finalizer for externally allocated memory
-    """
-    def mem_finalize(context, handle):
-        deallocations = context.deallocations
-
-        def core():
-            deallocations.add_item(dtor, handle, size=bytesize)
-
-        return core
-
-    return mem_finalize
-
-
-def _as_numba_devarray(intaddr, nelem, dtype, cb_dtor=None):
-    # Handle Datetime Column
-    if dtype == np.datetime64:
-        dtype = np.dtype('datetime64[ms]')
-    else:
-        dtype = np.dtype(dtype)
-    addr = ctypes.c_uint64(intaddr)
-    elemsize = dtype.itemsize
-    datasize = elemsize * nelem
-    finalizer = (_make_mem_finalizer(cb_dtor, datasize))
-    ctx = cuda.current_context()
-    if cb_dtor is None:
-        memptr = cuda.driver.MemoryPointer(context=ctx,
-                                           pointer=addr, size=datasize,
-                                           )
-    else:
-        memptr = cuda.driver.MemoryPointer(context=ctx,
-                                           pointer=addr, size=datasize,
-                                           finalizer=finalizer(ctx, addr)
-                                           )
-    return cuda.devicearray.DeviceNDArray(shape=(nelem,), strides=(elemsize,),
-                                          dtype=dtype, gpu_data=memptr)
-
-
 def cffi_view_to_column_mem(cffi_view):
-    data = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-                                                   cffi_view.data)),
-                              nelem=cffi_view.size,
-                              dtype=gdf_to_np_dtype(cffi_view.dtype),
-                              cb_dtor=cuda.driver.driver.cuMemFree)
+    intaddr=int(ffi.cast("uintptr_t", cffi_view.data))
+    data = rmm.device_array_from_ptr(intaddr,
+                                     nelem=cffi_view.size,
+                                     dtype=gdf_to_np_dtype(cffi_view.dtype),
+                                     finalizer=rmm._make_finalizer(intaddr, 0))
 
     if cffi_view.valid:
-        mask = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-                                              cffi_view.valid)),
-                                  nelem=calc_chunk_size(cffi_view.size,
-                                                        mask_bitsize),
-                                  dtype=mask_dtype,
-                                  cb_dtor=cuda.driver.driver.cuMemFree)
+        intaddr=int(ffi.cast("uintptr_t", cffi_view.valid))
+        mask = rmm.device_array_from_ptr(intaddr,
+                                         nelem=calc_chunk_size(cffi_view.size,
+                                                               mask_bitsize),
+                                         dtype=mask_dtype,
+                                         finalizer=rmm._make_finalizer(intaddr, 0))
     else:
         mask = None
 
@@ -308,16 +270,6 @@ def apply_join(col_lhs, col_rhs, how, method='hash'):
                col_result_r)
 
     # Extract result
-
-    # yield ((ary[0], ary[1]) if datasize > 0 else (ary, ary))
-
-    # left = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-    #                                                col_result_l.data)),
-    #                           nelem=col_result_l.size, dtype=np.int32)
-
-    # right = _as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-    #                                                 col_result_r.data)),
-    #                            nelem=col_result_r.size, dtype=np.int32)
 
     left = rmm.device_array_from_ptr(ptr = col_result_l.data,
                                      nelem=col_result_l.size, 
@@ -392,15 +344,15 @@ def libgdf_join(col_lhs, col_rhs, on, how, method='sort'):
     valids = []
 
     for col in result_cols:
-        res.append(_as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-                                                           col.data)),
-                                      nelem=col.size,
-                                      dtype=gdf_to_np_dtype(col.dtype)))
-        valids.append(_as_numba_devarray(intaddr=int(ffi.cast("uintptr_t",
-                                                              col.valid)),
-                                         nelem=calc_chunk_size(col.size,
-                                                               mask_bitsize),
-                                         dtype=mask_dtype))
+        res.append(rmm.device_array_from_ptr(ptr=int(ffi.cast("uintptr_t",
+                                                              col.data)),
+                                             nelem=col.size,
+                                             dtype=gdf_to_np_dtype(col.dtype)))
+        valids.append(rmm.device_array_from_ptr(ptr=int(ffi.cast("uintptr_t",
+                                                                 col.valid)),
+                                                nelem=calc_chunk_size(col.size,
+                                                                      mask_bitsize),
+                                                dtype=mask_dtype))
 
     return res, valids
 

--- a/pygdf/applyutils.py
+++ b/pygdf/applyutils.py
@@ -6,6 +6,8 @@ from numba.utils import pysignature, exec_
 from numba import six
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 from pygdf.docutils import docfmt_partial
 from pygdf import cudautils
 from pygdf.series import Series
@@ -93,7 +95,7 @@ class ApplyKernelCompilerBase(object):
         # Allocate output columns
         outputs = {}
         for k, dt in self.outcols.items():
-            outputs[k] = cuda.device_array(len(df), dtype=dt)
+            outputs[k] = rmm.device_array(len(df), dtype=dt)
         # Bind argument
         args = {}
         for dct in [inputs, outputs, self.kwargs]:

--- a/pygdf/buffer.py
+++ b/pygdf/buffer.py
@@ -2,6 +2,8 @@
 import numpy as np
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 from . import cudautils, utils
 from .serialize import register_distributed_serializer
 
@@ -21,7 +23,7 @@ class Buffer(object):
     def null(cls, dtype):
         """Create a "null" buffer with a zero-sized device array.
         """
-        mem = cuda.device_array(0, dtype=dtype)
+        mem = rmm.device_array(0, dtype=dtype)
         return cls(mem, size=0, capacity=0)
 
     def __init__(self, mem, size=None, capacity=None, categorical=False):
@@ -107,7 +109,7 @@ class Buffer(object):
             # Open IPC handle
             with ipch as data:
                 # Copy remote data over
-                mem = cuda.device_array_like(data)
+                mem = rmm.device_array_like(data)
                 mem.copy_to_device(data)
         # Not using IPC
         else:

--- a/pygdf/buffer.py
+++ b/pygdf/buffer.py
@@ -1,6 +1,4 @@
-
 import numpy as np
-from numba import cuda
 
 from librmm_cffi import librmm as rmm
 
@@ -71,9 +69,6 @@ class Buffer(object):
                 ipch = self._cached_ipch
             else:
                 # Get new IPC handle
-                # Old:
-                #ipch = self.to_gpu_array().get_ipc_handle()
-                # New:
                 ipch = rmm.get_ipc_handle(self.to_gpu_array())
 
             header['kind'] = 'ipc'

--- a/pygdf/buffer.py
+++ b/pygdf/buffer.py
@@ -71,7 +71,11 @@ class Buffer(object):
                 ipch = self._cached_ipch
             else:
                 # Get new IPC handle
-                ipch = self.to_gpu_array().get_ipc_handle()
+                # Old:
+                #ipch = self.to_gpu_array().get_ipc_handle()
+                # New:
+                ipch = rmm.get_ipc_handle(self.to_gpu_array())
+
             header['kind'] = 'ipc'
             header['mem'], frames = serialize(ipch)
             # Keep IPC handle alive

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -9,6 +9,8 @@ from numbers import Number
 import numpy as np
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 from . import _gdf
 from . import cudautils
 from . import utils
@@ -45,7 +47,7 @@ class Column(object):
         objs = [o for o in objs if len(o) > 0]
         newsize = sum(map(len, objs))
         # Concatenate data
-        mem = cuda.device_array(shape=newsize, dtype=head.data.dtype)
+        mem = rmm.device_array(shape=newsize, dtype=head.data.dtype)
         data = Buffer.from_empty(mem)
         for o in objs:
             data.extend(o.data.to_gpu_array())
@@ -53,7 +55,7 @@ class Column(object):
         # Concatenate mask if present
         if any(o.has_null_mask for o in objs):
             # FIXME: Inefficient
-            mem = cuda.device_array(shape=newsize, dtype=np.bool)
+            mem = rmm.device_array(shape=newsize, dtype=np.bool)
             mask = Buffer.from_empty(mem)
             null_count = 0
             for o in objs:
@@ -443,7 +445,7 @@ class Column(object):
                                       "yet supported")
         newsize = len(self) + len(other)
         # allocate memory
-        mem = cuda.device_array(shape=newsize, dtype=self.data.dtype)
+        mem = rmm.device_array(shape=newsize, dtype=self.data.dtype)
         newbuf = Buffer.from_empty(mem)
         # copy into new memory
         for buf in [self.data, other.data]:

--- a/pygdf/columnops.py
+++ b/pygdf/columnops.py
@@ -9,6 +9,8 @@ import pyarrow as pa
 
 from numba import cuda, njit
 
+from librmm_cffi import librmm as rmm
+
 from .buffer import Buffer
 from . import utils, cudautils, _gdf
 from .column import Column
@@ -70,7 +72,7 @@ class TypedColumnBase(Column):
 def column_empty_like(column, dtype, masked):
     """Allocate a new column like the given *column*
     """
-    data = cuda.device_array(shape=len(column), dtype=dtype)
+    data = rmm.device_array(shape=len(column), dtype=dtype)
     params = dict(data=Buffer(data))
     if masked:
         mask = utils.make_mask(data.size)
@@ -86,7 +88,7 @@ def column_empty_like_same_mask(column, dtype):
     dtype : np.dtype like
         The dtype of the data buffer.
     """
-    data = cuda.device_array(shape=len(column), dtype=dtype)
+    data = rmm.device_array(shape=len(column), dtype=dtype)
     params = dict(data=Buffer(data))
     if column.has_null_mask:
         params.update(mask=column.nullmask)
@@ -271,7 +273,7 @@ def column_applymap(udf, column, out_dtype):
     result : Buffer
     """
     core = njit(udf)
-    results = cuda.device_array(shape=len(column), dtype=out_dtype)
+    results = rmm.device_array(shape=len(column), dtype=out_dtype)
     values = column.data.to_gpu_array()
     if column.mask:
         # For masked columns

--- a/pygdf/columnops.py
+++ b/pygdf/columnops.py
@@ -154,7 +154,7 @@ def as_column(arbitrary):
         if arbitrary.dtype.kind == 'M':
             data = datetime.DatetimeColumn.from_numpy(arbitrary)
         else:
-            data = as_column(cuda.to_device(arbitrary))
+            data = as_column(rmm.to_device(arbitrary))
 
     elif isinstance(arbitrary, pa.Array):
         if isinstance(arbitrary, pa.StringArray):

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -15,6 +15,7 @@ def optimal_block_count(minblkct):
     """
     return min(16, max(1, minblkct))
 
+
 def to_device(ary):
     dary, _ = rmm.auto_device(ary)
     return dary

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -95,7 +95,7 @@ def astype(ary, dtype):
     if ary.dtype == np.dtype(dtype):
         return ary
     elif ary.size == 0:
-        return cuda.device_array(shape=ary.shape, dtype=dtype)
+        return rmm.device_array(shape=ary.shape, dtype=dtype)
     else:
         out = rmm.device_array(shape=ary.shape, dtype=dtype)
         configured = gpu_copy.forall(out.size)
@@ -191,7 +191,7 @@ def gpu_expand_mask_bits(bits, out):
 def expand_mask_bits(size, bits):
     """Expand bit-mask into byte-mask
     """
-    expanded_mask = cuda.device_array(size, dtype=np.int32)
+    expanded_mask = rmm.device_array(size, dtype=np.int32)
     numtasks = min(1024, expanded_mask.size)
     if numtasks > 0:
         gpu_expand_mask_bits.forall(numtasks)(bits, expanded_mask)

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from numba import cuda
 from numba.cuda.cudadrv.devicearray import DeviceNDArray
 
 from librmm_cffi import librmm as rmm
@@ -496,7 +495,7 @@ class DataFrame(object):
 
         if order == 'F':
             matrix = rmm.device_array(shape=(nrow, ncol), dtype=dtype,
-                                       order=order)
+                                      order=order)
             for colidx, inpcol in enumerate(cols):
                 dense = inpcol.to_gpu_array(fillna='pandas')
                 matrix[:, colidx].copy_to_device(dense)

--- a/pygdf/gpu_ipc_broker.py
+++ b/pygdf/gpu_ipc_broker.py
@@ -8,6 +8,8 @@ import socket
 import threading
 
 from numba import cuda
+from librmm_cffi import librmm as rmm
+
 
 try:
     import zmq
@@ -181,7 +183,7 @@ def _request_transfer(key, remoteinfo):
         # Open IPC and copy to local context
 
         with ipch as data:
-            copied = cuda.device_array_like(data)
+            copied = rmm.device_array_like(data)
             copied.copy_to_device(data)
 
         # Release
@@ -192,7 +194,7 @@ def _request_transfer(key, remoteinfo):
         logger.info("request by NET: %s->%s", theiraddr, myaddr)
         socket.send(pickle.dumps(('NET', key)))
         rcv = socket.recv()
-        output = cuda.to_device(pickle.loads(rcv))
+        output = rmm.to_device(pickle.loads(rcv))
         # Release
         _request_drop(socket, key)
         return output

--- a/pygdf/gpuarrow.py
+++ b/pygdf/gpuarrow.py
@@ -23,6 +23,7 @@ _NodeDesc = namedtuple(
 class MetadataParsingError(ValueError):
     pass
 
+
 # TODO: can this be replaced with calls to rmm.device_array_from_ptr()?
 def gpu_view_as(arr, dtype, shape=None, strides=None):
     dtype = np.dtype(dtype)

--- a/pygdf/gpuarrow.py
+++ b/pygdf/gpuarrow.py
@@ -23,7 +23,7 @@ _NodeDesc = namedtuple(
 class MetadataParsingError(ValueError):
     pass
 
-
+# TODO: can this be replaced with calls to rmm.device_array_from_ptr()?
 def gpu_view_as(arr, dtype, shape=None, strides=None):
     dtype = np.dtype(dtype)
     if strides is None:

--- a/pygdf/groupby.py
+++ b/pygdf/groupby.py
@@ -6,6 +6,7 @@ from itertools import chain
 import numpy as np
 
 from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from .dataframe import DataFrame, Series
 from .multi import concat
@@ -191,8 +192,8 @@ class Groupby(object):
             sr = grouped_df[k].reset_index()
             for newk, functor in infos.items():
                 if functor.__name__ == 'mean':
-                    dev_begins = cuda.to_device(np.asarray(begin))
-                    dev_out = cuda.device_array(size, dtype=np.float64)
+                    dev_begins = rmm.to_device(np.asarray(begin))
+                    dev_out = rmm.device_array(size, dtype=np.float64)
                     if size > 0:
                         group_mean.forall(size)(sr.to_gpu_array(),
                                                 dev_begins,
@@ -200,8 +201,8 @@ class Groupby(object):
                     values[newk] = dev_out
 
                 elif functor.__name__ == 'max':
-                    dev_begins = cuda.to_device(np.asarray(begin))
-                    dev_out = cuda.device_array(size, dtype=sr.dtype)
+                    dev_begins = rmm.to_device(np.asarray(begin))
+                    dev_out = rmm.device_array(size, dtype=sr.dtype)
                     if size > 0:
                         group_max.forall(size)(sr.to_gpu_array(),
                                                dev_begins,
@@ -209,8 +210,8 @@ class Groupby(object):
                     values[newk] = dev_out
 
                 elif functor.__name__ == 'min':
-                    dev_begins = cuda.to_device(np.asarray(begin))
-                    dev_out = cuda.device_array(size, dtype=sr.dtype)
+                    dev_begins = rmm.to_device(np.asarray(begin))
+                    dev_out = rmm.device_array(size, dtype=sr.dtype)
                     if size > 0:
                         group_min.forall(size)(sr.to_gpu_array(),
                                                dev_begins,

--- a/pygdf/index.py
+++ b/pygdf/index.py
@@ -7,6 +7,8 @@ import numpy as np
 import pickle
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 from . import cudautils, utils, columnops
 from .buffer import Buffer
 from .numerical import NumericalColumn
@@ -182,7 +184,7 @@ class RangeIndex(Index):
         if len(self) > 0:
             vals = cudautils.arange(self._start, self._stop, dtype=self.dtype)
         else:
-            vals = cuda.device_array(0, dtype=self.dtype)
+            vals = rmm.device_array(0, dtype=self.dtype)
         return NumericalColumn(data=Buffer(vals), dtype=vals.dtype)
 
     def to_pandas(self):

--- a/pygdf/index.py
+++ b/pygdf/index.py
@@ -5,7 +5,6 @@ from __future__ import print_function, division
 import pandas as pd
 import numpy as np
 import pickle
-from numba import cuda
 
 from librmm_cffi import librmm as rmm
 

--- a/pygdf/libgdf_groupby.py
+++ b/pygdf/libgdf_groupby.py
@@ -8,6 +8,7 @@ from .dataframe import DataFrame, Series
 from .buffer import Buffer
 
 from libgdf_cffi import ffi, libgdf
+from librmm_cffi import librmm as rmm
 
 
 class LibGdfGroupby(object):
@@ -87,13 +88,13 @@ class LibGdfGroupby(object):
             # aggregated results will be in the same order for GDF_SORT method
             if need_to_index:
                 out_col_indices_series = Series(
-                    Buffer(cuda.device_array(col_agg.size, dtype=np.int32)))
+                    Buffer(rmm.device_array(col_agg.size, dtype=np.int32)))
                 out_col_indices = out_col_indices_series._column.cffi_view
             else:
                 out_col_indices = ffi.NULL
 
             if first_run or self._method == libgdf.GDF_HASH:
-                out_col_values_series = [Series(Buffer(cuda.device_array(
+                out_col_values_series = [Series(Buffer(rmm.device_array(
                     col_agg.size,
                     dtype=self._df[self._by[i]]._column.data.dtype)))
                     for i in range(0, ncols)]
@@ -105,9 +106,9 @@ class LibGdfGroupby(object):
 
             if agg_type == "count":
                 out_col_agg_series = Series(
-                    Buffer(cuda.device_array(col_agg.size, dtype=np.int64)))
+                    Buffer(rmm.device_array(col_agg.size, dtype=np.int64)))
             else:
-                out_col_agg_series = Series(Buffer(cuda.device_array(
+                out_col_agg_series = Series(Buffer(rmm.device_array(
                     col_agg.size, dtype=self._df[val_col]._column.data.dtype)))
 
             out_col_agg = out_col_agg_series._column.cffi_view

--- a/pygdf/libgdf_groupby.py
+++ b/pygdf/libgdf_groupby.py
@@ -3,7 +3,6 @@
 import numpy as np
 import collections
 
-from numba import cuda
 from .dataframe import DataFrame, Series
 from .buffer import Buffer
 

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 
 from numba import cuda
 from libgdf_cffi import libgdf
+from librmm_cffi import librmm as rmm
 
 from . import _gdf, columnops, utils, cudautils
 from .buffer import Buffer
@@ -390,7 +391,7 @@ def column_hash_values(column0, *other_columns):
     Returns a new NumericalColumn[int32]
     """
     columns = [column0] + list(other_columns)
-    buf = Buffer(cuda.device_array(len(column0), dtype=np.int32))
+    buf = Buffer(rmm.device_array(len(column0), dtype=np.int32))
     result = NumericalColumn(data=buf, dtype=buf.dtype)
     _gdf.hash_columns(columns, result)
     return result

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from numba import cuda
 from libgdf_cffi import libgdf
 from librmm_cffi import librmm as rmm
 

--- a/pygdf/queryutils.py
+++ b/pygdf/queryutils.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 
 ENVREF_PREFIX = '__PYGDF_ENVREF__'
 
@@ -214,7 +216,7 @@ def query_execute(df, expr, callenv):
     colarrays = [df[col].to_gpu_array() for col in compiled['colnames']]
     # allocate output buffer
     nrows = len(df)
-    out = cuda.device_array(nrows, dtype=np.bool_)
+    out = rmm.device_array(nrows, dtype=np.bool_)
     # run kernel
     args = [out] + colarrays + envargs
     kernel.forall(nrows)(*args)

--- a/pygdf/tests/conftest.py
+++ b/pygdf/tests/conftest.py
@@ -8,4 +8,4 @@ from librmm_cffi import librmm
 def rmm():
     librmm.initialize()
     yield librmm 
-    #librmm.finalize()
+    librmm.finalize()

--- a/pygdf/tests/conftest.py
+++ b/pygdf/tests/conftest.py
@@ -2,10 +2,11 @@ import pytest
 
 from librmm_cffi import librmm
 
-# Set up a fixture for the RMM memory manager to initialize and finalize it before
-# and after tests.
+
+# Set up a fixture for the RMM memory manager to initialize and finalize it
+# before and after tests.
 @pytest.fixture(scope="session", autouse=True)
 def rmm():
     librmm.initialize()
-    yield librmm 
+    yield librmm
     librmm.finalize()

--- a/pygdf/tests/conftest.py
+++ b/pygdf/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from librmm_cffi import librmm
+
+# Set up a fixture for the RMM memory manager to initialize and finalize it before
+# and after tests.
+@pytest.fixture(scope="session", autouse=True)
+def rmm():
+    librmm.initialize()
+    yield librmm 
+    #librmm.finalize()

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -6,8 +6,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from numba import cuda
-
 from librmm_cffi import librmm as rmm
 
 import pygdf as gd

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -8,6 +8,8 @@ import pyarrow as pa
 
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 import pygdf as gd
 from pygdf.dataframe import Series, DataFrame
 from pygdf.buffer import Buffer
@@ -115,7 +117,7 @@ def test_dataframe_basic():
     df = DataFrame()
 
     # Populate with cuda memory
-    df['keys'] = cuda.to_device(np.arange(10, dtype=np.float64))
+    df['keys'] = rmm.to_device(np.arange(10, dtype=np.float64))
     np.testing.assert_equal(df['keys'].to_array(), np.arange(10))
     assert len(df) == 10
 

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -489,7 +489,7 @@ def test_dataframe_setitem_from_masked_object():
     assert(test2['a'].has_null_mask)
     assert(test2['a'].null_count == 20)
 
-    gpu_ary = cuda.to_device(ary)
+    gpu_ary = rmm.to_device(ary)
     test3 = Series(gpu_ary)
     assert(test3.has_null_mask)
     assert(test3.null_count == 20)

--- a/pygdf/tests/test_gpu_arrow_parser.py
+++ b/pygdf/tests/test_gpu_arrow_parser.py
@@ -13,6 +13,8 @@ except ImportError as msg:
 import numpy as np
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 from pygdf.gpuarrow import GpuArrowReader
 
 
@@ -42,7 +44,7 @@ def test_gpu_parse_arrow_data():
                             buffer=bytearray(schema_data))
     cpu_data = np.ndarray(shape=len(recbatch_data), dtype=np.byte,
                           buffer=bytearray(recbatch_data))
-    gpu_data = cuda.to_device(cpu_data)
+    gpu_data = rmm.to_device(cpu_data)
     del cpu_data
 
     # test reader
@@ -129,7 +131,7 @@ def test_gpu_parse_arrow_cats():
                         buffer=bytearray(schema_bytes))
     rb_cpu_data = np.ndarray(shape=len(recordbatches_bytes), dtype=np.byte,
                              buffer=bytearray(recordbatches_bytes))
-    rb_gpu_data = cuda.to_device(rb_cpu_data)
+    rb_gpu_data = rmm.to_device(rb_cpu_data)
 
     gar = GpuArrowReader(schema, rb_gpu_data)
     columns = gar.to_dict()
@@ -183,7 +185,7 @@ def test_gpu_parse_arrow_int16():
     rb_cpu_data = np.ndarray(shape=len(recordbatches_bytes), dtype=np.byte,
                              buffer=bytearray(recordbatches_bytes))
 
-    rb_gpu_data = cuda.to_device(rb_cpu_data)
+    rb_gpu_data = rmm.to_device(rb_cpu_data)
     gar = GpuArrowReader(schema, rb_gpu_data)
     columns = gar.to_dict()
     assert columns['depdelay'].dtype == np.int16

--- a/pygdf/tests/test_gpu_arrow_parser.py
+++ b/pygdf/tests/test_gpu_arrow_parser.py
@@ -11,7 +11,6 @@ except ImportError as msg:
     arrow_version = None
 
 import numpy as np
-from numba import cuda
 
 from librmm_cffi import librmm as rmm
 

--- a/pygdf/tests/test_pickling.py
+++ b/pygdf/tests/test_pickling.py
@@ -4,7 +4,6 @@ import sys
 import pickle
 
 import numpy as np
-from numba import cuda
 import pandas as pd
 
 from librmm_cffi import librmm as rmm

--- a/pygdf/tests/test_pickling.py
+++ b/pygdf/tests/test_pickling.py
@@ -7,6 +7,8 @@ import numpy as np
 from numba import cuda
 import pandas as pd
 
+from librmm_cffi import librmm as rmm
+
 from pygdf.dataframe import DataFrame, GenericIndex
 from pygdf.buffer import Buffer
 
@@ -68,7 +70,7 @@ def test_sizeof_dataframe():
 
 def test_pickle_index():
     nelem = 10
-    idx = GenericIndex(cuda.to_device(np.arange(nelem)))
+    idx = GenericIndex(rmm.to_device(np.arange(nelem)))
     pickled = pickle.dumps(idx)
     out = pickle.loads(pickled)
     assert idx == out

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -125,19 +125,21 @@ def test_serialize_ipc():
     proc.start()
     out = result_queue.get()
     proc.join(3)
+
     # Verify that the output array matches the source
     np.testing.assert_array_equal(out.to_array(), sr.to_array())
 
 
 def _load_ipc(header, frames, result_queue):
     pygdf._gdf.rmm_initialize()
+
     try:   
         out = deserialize(header, frames)
         result_queue.put(out)
     except Exception as e:
         result_queue.put(e)
-    pygdf._gdf.rmm_finalize()
-    
+
+    import atexit; atexit.register(pygdf._gdf.rmm_finalize)
 
 
 @require_distributed

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -130,11 +130,14 @@ def test_serialize_ipc():
 
 
 def _load_ipc(header, frames, result_queue):
+    pygdf._gdf.rmm_initialize()
     try:   
         out = deserialize(header, frames)
         result_queue.put(out)
     except Exception as e:
         result_queue.put(e)
+    pygdf._gdf.rmm_finalize()
+    
 
 
 @require_distributed

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
 import sys
+import atexit
 import multiprocessing as mp
 
 import numpy as np
@@ -95,7 +96,6 @@ def test_serialize_groupby():
     pd.util.testing.assert_frame_equal(got.to_pandas(), expect.to_pandas())
 
 
-# TODO: this test currently fails because RMM is not initialized in the spawned process!
 @require_distributed
 @require_ipc
 def test_serialize_ipc():
@@ -133,13 +133,13 @@ def test_serialize_ipc():
 def _load_ipc(header, frames, result_queue):
     pygdf._gdf.rmm_initialize()
 
-    try:   
+    try:
         out = deserialize(header, frames)
         result_queue.put(out)
     except Exception as e:
         result_queue.put(e)
 
-    import atexit; atexit.register(pygdf._gdf.rmm_finalize)
+    atexit.register(pygdf._gdf.rmm_finalize)
 
 
 @require_distributed

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -96,10 +96,7 @@ def test_serialize_groupby():
     pd.util.testing.assert_frame_equal(got.to_pandas(), expect.to_pandas())
 
 
-@require_distributed
-@require_ipc
-def test_serialize_ipc():
-    sr = pygdf.Series(np.arange(10))
+def serialize_ipc(sr):
     # Non-IPC
     header, frames = serialize(sr)
     assert header['column']['data_buffer']['kind'] == 'normal'
@@ -125,9 +122,26 @@ def test_serialize_ipc():
     proc.start()
     out = result_queue.get()
     proc.join(3)
+    return out
 
+
+@require_distributed
+@require_ipc
+def test_serialize_ipc():
+    sr = pygdf.Series(np.arange(10))
+    out = serialize_ipc(sr)
     # Verify that the output array matches the source
     np.testing.assert_array_equal(out.to_array(), sr.to_array())
+
+
+@require_distributed
+@require_ipc
+def test_serialize_ipc_slice():
+    sr = pygdf.Series(np.arange(10))
+    # test with a slice to verify internal offset calculations work
+    out = serialize_ipc(sr[1:7])
+    # Verify that the output array matches the source
+    np.testing.assert_array_equal(out.to_array(), sr[1:7].to_array())
 
 
 def _load_ipc(header, frames, result_queue):

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -95,6 +95,7 @@ def test_serialize_groupby():
     pd.util.testing.assert_frame_equal(got.to_pandas(), expect.to_pandas())
 
 
+# TODO: this test currently fails because RMM is not initialized in the spawned process!
 @require_distributed
 @require_ipc
 def test_serialize_ipc():
@@ -129,7 +130,7 @@ def test_serialize_ipc():
 
 
 def _load_ipc(header, frames, result_queue):
-    try:
+    try:   
         out = deserialize(header, frames)
         result_queue.put(out)
     except Exception as e:

--- a/pygdf/tests/test_sparse_df.py
+++ b/pygdf/tests/test_sparse_df.py
@@ -11,7 +11,6 @@ except ImportError as msg:
     arrow_version = None
 
 import numpy as np
-from numba import cuda
 
 from librmm_cffi import librmm as rmm
 

--- a/pygdf/tests/test_sparse_df.py
+++ b/pygdf/tests/test_sparse_df.py
@@ -13,6 +13,8 @@ except ImportError as msg:
 import numpy as np
 from numba import cuda
 
+from librmm_cffi import librmm as rmm
+
 from pygdf.gpuarrow import GpuArrowReader
 from pygdf.dataframe import Series, DataFrame
 
@@ -34,7 +36,7 @@ def read_data():
     data = batch.serialize().to_pybytes()
     data = np.ndarray(shape=len(data), dtype=np.byte,
                       buffer=bytearray(data))
-    darr = cuda.to_device(data)
+    darr = rmm.to_device(data)
     return schema, darr
 
 

--- a/pygdf/utils.py
+++ b/pygdf/utils.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import numpy as np
 
-from numba import njit, cuda
+from numba import njit
 
 from librmm_cffi import librmm as rmm
 

--- a/pygdf/utils.py
+++ b/pygdf/utils.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from numba import njit, cuda
 
+from librmm_cffi import librmm as rmm
+
 mask_dtype = np.dtype(np.uint8)
 mask_bitsize = mask_dtype.itemsize * 8
 
@@ -39,7 +41,7 @@ def make_mask(size):
     """Create mask to obtain at least *size* number of bits.
     """
     size = calc_chunk_size(size, mask_bitsize)
-    return cuda.device_array(shape=size, dtype=mask_dtype)
+    return rmm.device_array(shape=size, dtype=mask_dtype)
 
 
 def require_writeable_array(arr):
@@ -52,7 +54,7 @@ def scalar_broadcast_to(scalar, shape, dtype):
 
     if not isinstance(shape, tuple):
         shape = (shape,)
-    da = cuda.device_array(shape, dtype=dtype)
+    da = rmm.device_array(shape, dtype=dtype)
     if da.size != 0:
         fill_value(da, scalar)
     return da


### PR DESCRIPTION
Modifications to use the RMM Memory Manager in pygdf. This depends on the sister PR for libgdf: https://github.com/gpuopenanalytics/libgdf/pull/159

RMM provides a Python API compatible with `cuda.device_array`, `cuda.to_device`, `cuda.device_array_like`, etc. from Numba. To use them, `from librmm_cffi import rmmlib as rmm` and just replace `cuda` in the above functions with `rmm`.

This is a work in progress.