### PR TITLE
[REVIEW] Quantile bindings

### DIFF
--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -598,10 +598,14 @@ _GDF_QUANTILE_METHODS = {
     'midpoint': libgdf.GDF_QUANT_MIDPOINT,
     'nearest': libgdf.GDF_QUANT_NEAREST,
 }
+
+
 def get_quantile_method(method):
     """Util to convert method to gdf gdf_quantile_method.
     """
     return _GDF_QUANTILE_METHODS[method]
+
+
 def quantile(column, quant, method, exact):
     """ Calculate the `quant` quantile for the column
     Returns value with the quantile specified by quant
@@ -627,4 +631,3 @@ def quantile(column, quant, method, exact):
                                        gdf_context)
         res.append(px[0])
     return res
-

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -280,9 +280,9 @@ def apply_join(col_lhs, col_rhs, how, method='hash'):
     gdf_context = ffi.new('gdf_context*')
 
     if method == 'hash':
-        libgdf.gdf_context_view(gdf_context, 0, method_api, 0)
+        libgdf.gdf_context_view(gdf_context, 0, method_api, 0, 0, 0)
     elif method == 'sort':
-        libgdf.gdf_context_view(gdf_context, 1, method_api, 0)
+        libgdf.gdf_context_view(gdf_context, 1, method_api, 0, 0, 0)
     else:
         msg = "method not supported"
         raise ValueError(msg)
@@ -328,7 +328,7 @@ def libgdf_join(col_lhs, col_rhs, on, how, method='sort'):
     method_api = _join_method_api[method]
     gdf_context = ffi.new('gdf_context*')
 
-    libgdf.gdf_context_view(gdf_context, 0, method_api, 0)
+    libgdf.gdf_context_view(gdf_context, 0, method_api, 0, 0, 0)
 
     if how not in ['left', 'inner']:
         msg = "new join api only supports left or inner"
@@ -612,7 +612,7 @@ def quantile(column, quant, method, exact):
     """
     gdf_context = ffi.new('gdf_context*')
     method_api = _join_method_api['sort']
-    libgdf.gdf_context_view_augmented(gdf_context, 0, method_api, 0, 0, 0)
+    libgdf.gdf_context_view(gdf_context, 0, method_api, 0, 0, 0)
     # libgdf.gdf_context_view(gdf_context, 0, method_api, 0)
     # px = ffi.new("double *")
     res = []

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -472,4 +472,3 @@ class Column(object):
             msg = "`q` must be either a single element, list or numpy array"
             raise TypeError(msg)
         return _gdf.quantile(self, quant, interpolation, exact)
-

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -462,3 +462,14 @@ class Column(object):
             newbuf.extend(buf.to_gpu_array())
         # return new column
         return self.replace(data=newbuf)
+
+    def quantile(self, q, interpolation, exact):
+        if isinstance(q, Number):
+            quant = [q]
+        elif isinstance(q, list) or isinstance(q, np.ndarray):
+            quant = q
+        else:
+            msg = "`q` must be either a single element, list or numpy array"
+            raise TypeError(msg)
+        return _gdf.quantile(self, quant, interpolation, exact)
+

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -1388,6 +1388,31 @@ class DataFrame(object):
             return df.set_index(indices.astype(np.int64))
         return df
 
+    def quantile(self, q, interpolation='linear', exact=False):
+        """Return values at the given quantile.
+        Parameters
+        ----------
+        q : float or array-like
+            0 <= q <= 1, the quantile(s) to compute
+        interpolation : {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+            This  parameter specifies the interpolation method to use,
+            when the desired quantile lies between two data points i and j.
+            Default 'linear'.
+        columns : list of str
+            List of column names to include.
+        exact : boolean
+            Whether to use approximate or exact quantile algorithm.
+        Returns
+        -------
+        DataFrame
+        """
+        result = DataFrame()
+        result['Quantile'] = q
+        for k, col in self._cols.items():
+            result[k] = col.quantile(q, interpolation, exact,
+                                     quant_index=False)
+        print(result)
+
 
 class Loc(object):
     """

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -854,7 +854,6 @@ class Series(object):
 
         return Series(numerical.column_hash_values(self._column))
 
-
     def quantile(self, q, interpolation='midpoint', exact=True,
                  quant_index=True):
         """Return values at the given quantile.

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -855,6 +855,33 @@ class Series(object):
         return Series(numerical.column_hash_values(self._column))
 
 
+    def quantile(self, q, interpolation='midpoint', exact=True,
+                 quant_index=True):
+        """Return values at the given quantile.
+        Parameters
+        ----------
+        q : float or array-like, default 0.5 (50% quantile)
+            0 <= q <= 1, the quantile(s) to compute
+        interpolation : {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+            This optional parameter specifies the interpolation method to use,
+            when the desired quantile lies between two data points i and j:
+        columns : list of str
+            List of column names to include.
+        exact : boolean
+            Whether to use approximate or exact quantile algorithm.
+        quant_index : boolean
+            Whether to use the list of quantiles as index.
+        Returns
+        -------
+        DataFrame
+        """
+        if not quant_index:
+            return Series(self._column.quantile(q, interpolation, exact))
+        else:
+            return Series(self._column.quantile(q, interpolation, exact),
+                          index=GenericIndex(np.asarray(q)))
+
+
 register_distributed_serializer(Series)
 
 

--- a/pygdf/tests/test_stats.py
+++ b/pygdf/tests/test_stats.py
@@ -86,17 +86,16 @@ def test_series_scale():
     np.testing.assert_equal(sr.scale().to_array(), scaled)
 
 
-
 @pytest.mark.parametrize('int_method', interpolation_methods)
 def test_exact_quantiles(int_method):
     arr = np.asarray([6.8, 0.15, 3.4, 4.17, 2.13, 1.11, -1.01, 0.8, 5.7])
     quant_values = [0.0, 0.25, 0.33, 0.5, 1.0]
-    
+
     gdf_series = Series(arr)
-    
+
     q1 = gdf_series.quantile(quant_values, interpolation=int_method,
                              exact=True)
-    
+
     np.testing.assert_allclose(q1.to_pandas().values,
                                exact_results[int_method], rtol=1e-10)
 
@@ -104,10 +103,10 @@ def test_exact_quantiles(int_method):
 def test_approx_quantiles():
     arr = np.asarray([6.8, 0.15, 3.4, 4.17, 2.13, 1.11, -1.01, 0.8, 5.7])
     quant_values = [0.0, 0.25, 0.33, 0.5, 1.0]
-    
+
     gdf_series = Series(arr)
-    
+
     q1 = gdf_series.quantile(quant_values, exact=False)
-    
+
     np.testing.assert_allclose(q1.to_pandas().values, approx_results,
                                rtol=1e-10)

--- a/pygdf/tests/test_stats.py
+++ b/pygdf/tests/test_stats.py
@@ -11,6 +11,15 @@ from pygdf.dataframe import Series
 params_dtypes = [np.int32, np.float32, np.float64]
 methods = ['min', 'max', 'sum', 'mean', 'var', 'std']
 
+interpolation_methods = ['linear', 'lower', 'higher', 'midpoint', 'nearest']
+exact_results = {
+    'linear': [-1.01, 0.3125, 0.7805, 1.62, 6.8],
+    'lower': [-1.01, 0.15, 0.15, 1.11, 6.8],
+    'higher': [0.15, 0.8, 0.8, 2.13, 6.8],
+    'midpoint': [-0.43, 0.475, 0.475, 1.62, 6.8],
+    'nearest': [-1.01, 0.15, 0.8, 2.13, 6.8]}
+approx_results = [-1.01, 0.15, 0.15, 1.11, 6.8]
+
 
 @pytest.mark.parametrize('method', methods)
 @pytest.mark.parametrize('dtype', params_dtypes)
@@ -75,3 +84,30 @@ def test_series_scale():
     assert scaled.min() == 0
     assert scaled.max() == 1
     np.testing.assert_equal(sr.scale().to_array(), scaled)
+
+
+
+@pytest.mark.parametrize('int_method', interpolation_methods)
+def test_exact_quantiles(int_method):
+    arr = np.asarray([6.8, 0.15, 3.4, 4.17, 2.13, 1.11, -1.01, 0.8, 5.7])
+    quant_values = [0.0, 0.25, 0.33, 0.5, 1.0]
+    
+    gdf_series = Series(arr)
+    
+    q1 = gdf_series.quantile(quant_values, interpolation=int_method,
+                             exact=True)
+    
+    np.testing.assert_allclose(q1.to_pandas().values,
+                               exact_results[int_method], rtol=1e-10)
+
+
+def test_approx_quantiles():
+    arr = np.asarray([6.8, 0.15, 3.4, 4.17, 2.13, 1.11, -1.01, 0.8, 5.7])
+    quant_values = [0.0, 0.25, 0.33, 0.5, 1.0]
+    
+    gdf_series = Series(arr)
+    
+    q1 = gdf_series.quantile(quant_values, exact=False)
+    
+    np.testing.assert_allclose(q1.to_pandas().values, approx_results,
+                               rtol=1e-10)


### PR DESCRIPTION
Exposed libgdf quantile functionality in `dataframe.py` and `series.py`. Main difference from pandas, if calculating multiple quantiles in `dataframe.py` it returns a dataframe with 2 columns: the requested quantiles and the calculated values. Pandas returns the quantiles as indices. Could add that functionality depending on review feedback. 